### PR TITLE
Initial Wrapper 0 Flutter app scaffold (Riverpod, go_router, mock analytics)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'router.dart';
+import 'theme.dart';
+
+class Wrapper0App extends ConsumerWidget {
+  const Wrapper0App({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(routerProvider);
+    final themeMode = ref.watch(themeModeProvider);
+    return MaterialApp.router(
+      title: 'Wrapper 0',
+      theme: WrapperTheme.light(),
+      darkTheme: WrapperTheme.dark(),
+      themeMode: themeMode,
+      routerConfig: router,
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../features/categories/categories_screen.dart';
+import '../features/home/home_screen.dart';
+import '../features/onboarding/onboarding_screen.dart';
+import '../features/settings/settings_screen.dart';
+import '../features/wrapped/wrapped_screen.dart';
+import '../features/categories/category_detail_screen.dart';
+
+final routerProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    initialLocation: '/onboarding',
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        builder: (context, state) => const OnboardingScreen(),
+      ),
+      ShellRoute(
+        builder: (context, state, child) => ShellScaffold(child: child),
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const HomeScreen(),
+          ),
+          GoRoute(
+            path: '/categories',
+            builder: (context, state) => const CategoriesScreen(),
+          ),
+          GoRoute(
+            path: '/wrapped',
+            builder: (context, state) => const WrappedScreen(),
+          ),
+          GoRoute(
+            path: '/settings',
+            builder: (context, state) => const SettingsScreen(),
+          ),
+          GoRoute(
+            path: '/category/:id',
+            builder: (context, state) => CategoryDetailScreen(
+              categoryId: state.pathParameters['id'] ?? 'music',
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+});
+
+class ShellScaffold extends StatefulWidget {
+  const ShellScaffold({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<ShellScaffold> createState() => _ShellScaffoldState();
+}
+
+class _ShellScaffoldState extends State<ShellScaffold> {
+  int _indexFromLocation(String location) {
+    if (location.startsWith('/categories')) return 1;
+    if (location.startsWith('/wrapped')) return 2;
+    if (location.startsWith('/settings')) return 3;
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final location = GoRouterState.of(context).uri.toString();
+    final index = _indexFromLocation(location);
+    return Scaffold(
+      body: widget.child,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: index,
+        onDestinationSelected: (value) {
+          switch (value) {
+            case 1:
+              context.go('/categories');
+              break;
+            case 2:
+              context.go('/wrapped');
+              break;
+            case 3:
+              context.go('/settings');
+              break;
+            default:
+              context.go('/');
+          }
+        },
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+          NavigationDestination(icon: Icon(Icons.grid_view), label: 'Categories'),
+          NavigationDestination(icon: Icon(Icons.auto_awesome), label: 'Wrapped'),
+          NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.dark);
+
+class WrapperTheme {
+  static ThemeData dark() {
+    const primary = Color(0xFF7C3AED);
+    const accent = Color(0xFF22D3EE);
+    return ThemeData(
+      brightness: Brightness.dark,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: primary,
+        brightness: Brightness.dark,
+      ).copyWith(
+        secondary: accent,
+        surface: const Color(0xFF0B0B10),
+      ),
+      scaffoldBackgroundColor: const Color(0xFF0B0B10),
+      useMaterial3: true,
+      textTheme: _textTheme,
+      cardTheme: const CardTheme(
+        color: Color(0xFF12121A),
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(20)),
+        ),
+      ),
+    );
+  }
+
+  static ThemeData light() {
+    const primary = Color(0xFF7C3AED);
+    const accent = Color(0xFF22D3EE);
+    return ThemeData(
+      brightness: Brightness.light,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: primary,
+        brightness: Brightness.light,
+      ).copyWith(secondary: accent),
+      useMaterial3: true,
+      textTheme: _textTheme,
+      cardTheme: const CardTheme(
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(20)),
+        ),
+      ),
+    );
+  }
+
+  static const TextTheme _textTheme = TextTheme(
+    displayLarge: TextStyle(fontWeight: FontWeight.w700),
+    displayMedium: TextStyle(fontWeight: FontWeight.w700),
+    displaySmall: TextStyle(fontWeight: FontWeight.w700),
+    headlineMedium: TextStyle(fontWeight: FontWeight.w600),
+    headlineSmall: TextStyle(fontWeight: FontWeight.w600),
+    titleLarge: TextStyle(fontWeight: FontWeight.w600),
+  );
+}

--- a/lib/data/models/activity_aggregates.dart
+++ b/lib/data/models/activity_aggregates.dart
@@ -1,0 +1,51 @@
+class SocialActivityAggregate {
+  const SocialActivityAggregate({
+    required this.id,
+    required this.appId,
+    required this.periodKey,
+    this.reelsWatchedCount,
+    this.storiesPostedCount,
+    this.postsCreatedCount,
+  });
+
+  final String id;
+  final String appId;
+  final String periodKey;
+  final int? reelsWatchedCount;
+  final int? storiesPostedCount;
+  final int? postsCreatedCount;
+}
+
+class MessagingActivityAggregate {
+  const MessagingActivityAggregate({
+    required this.id,
+    required this.appId,
+    required this.periodKey,
+    required this.messagesSentApproxCount,
+    required this.callsDurationMsApprox,
+    required this.callsCountApprox,
+  });
+
+  final String id;
+  final String appId;
+  final String periodKey;
+  final int messagesSentApproxCount;
+  final int callsDurationMsApprox;
+  final int callsCountApprox;
+}
+
+class VideoActivityAggregate {
+  const VideoActivityAggregate({
+    required this.id,
+    required this.appId,
+    required this.periodKey,
+    required this.videosWatchedApproxCount,
+    required this.watchTimeMs,
+  });
+
+  final String id;
+  final String appId;
+  final String periodKey;
+  final int videosWatchedApproxCount;
+  final int watchTimeMs;
+}

--- a/lib/data/models/app_info.dart
+++ b/lib/data/models/app_info.dart
@@ -1,0 +1,17 @@
+enum AppCategory { music, photos, social, messaging, video, other }
+
+class AppInfo {
+  const AppInfo({
+    required this.id,
+    required this.packageName,
+    required this.displayName,
+    required this.category,
+    required this.platform,
+  });
+
+  final String id;
+  final String packageName;
+  final String displayName;
+  final AppCategory category;
+  final String platform;
+}

--- a/lib/data/models/models.dart
+++ b/lib/data/models/models.dart
@@ -1,0 +1,4 @@
+export 'app_info.dart';
+export 'usage_session.dart';
+export 'photo_event.dart';
+export 'activity_aggregates.dart';

--- a/lib/data/models/photo_event.dart
+++ b/lib/data/models/photo_event.dart
@@ -1,0 +1,13 @@
+enum PhotoEventType { created, deleted }
+
+class PhotoEvent {
+  const PhotoEvent({
+    required this.id,
+    required this.type,
+    required this.timestamp,
+  });
+
+  final String id;
+  final PhotoEventType type;
+  final DateTime timestamp;
+}

--- a/lib/data/models/usage_session.dart
+++ b/lib/data/models/usage_session.dart
@@ -1,0 +1,23 @@
+class UsageSession {
+  const UsageSession({
+    required this.id,
+    required this.appId,
+    required this.startTimestamp,
+    required this.endTimestamp,
+    required this.durationMs,
+    required this.dayKey,
+    required this.weekKey,
+    required this.monthKey,
+    required this.yearKey,
+  });
+
+  final String id;
+  final String appId;
+  final DateTime startTimestamp;
+  final DateTime endTimestamp;
+  final int durationMs;
+  final String dayKey;
+  final String weekKey;
+  final String monthKey;
+  final String yearKey;
+}

--- a/lib/data/repositories/mock_repository.dart
+++ b/lib/data/repositories/mock_repository.dart
@@ -1,0 +1,72 @@
+import 'dart:math';
+
+import '../models/models.dart';
+
+class MockRepository {
+  final _random = Random(24);
+
+  List<AppInfo> loadApps() {
+    return const [
+      AppInfo(
+        id: 'spotify',
+        packageName: 'com.spotify.music',
+        displayName: 'Spotify',
+        category: AppCategory.music,
+        platform: 'android',
+      ),
+      AppInfo(
+        id: 'insta',
+        packageName: 'com.instagram.android',
+        displayName: 'Instagram',
+        category: AppCategory.social,
+        platform: 'android',
+      ),
+      AppInfo(
+        id: 'whatsapp',
+        packageName: 'com.whatsapp',
+        displayName: 'WhatsApp',
+        category: AppCategory.messaging,
+        platform: 'android',
+      ),
+      AppInfo(
+        id: 'youtube',
+        packageName: 'com.google.android.youtube',
+        displayName: 'YouTube',
+        category: AppCategory.video,
+        platform: 'android',
+      ),
+      AppInfo(
+        id: 'photos',
+        packageName: 'com.google.android.apps.photos',
+        displayName: 'Photos',
+        category: AppCategory.photos,
+        platform: 'android',
+      ),
+    ];
+  }
+
+  List<UsageSession> loadUsageSessions() {
+    final now = DateTime.now();
+    return List.generate(20, (index) {
+      final start = now.subtract(Duration(hours: index * 3 + 1));
+      final duration = (_random.nextInt(80) + 10) * 60 * 1000;
+      return UsageSession(
+        id: 'session_$index',
+        appId: loadApps()[index % 5].id,
+        startTimestamp: start,
+        endTimestamp: start.add(Duration(milliseconds: duration)),
+        durationMs: duration,
+        dayKey: '${start.year}-${start.month}-${start.day}',
+        weekKey: '${start.year}-W${_weekOfYear(start)}',
+        monthKey: '${start.year}-${start.month}',
+        yearKey: '${start.year}',
+      );
+    });
+  }
+
+  int _weekOfYear(DateTime date) {
+    final firstDay = DateTime(date.year, 1, 1);
+    final days = date.difference(firstDay).inDays;
+    return (days / 7).floor() + 1;
+  }
+}

--- a/lib/domain/aggregator.dart
+++ b/lib/domain/aggregator.dart
@@ -1,0 +1,49 @@
+import '../data/models/models.dart';
+
+class UsageAggregate {
+  const UsageAggregate({
+    required this.totalDurationMs,
+    required this.topApps,
+  });
+
+  final int totalDurationMs;
+  final List<AppUsageSummary> topApps;
+}
+
+class AppUsageSummary {
+  const AppUsageSummary({
+    required this.app,
+    required this.durationMs,
+  });
+
+  final AppInfo app;
+  final int durationMs;
+}
+
+class UsageAggregator {
+  UsageAggregate summarize(List<AppInfo> apps, List<UsageSession> sessions) {
+    final totals = <String, int>{};
+    for (final session in sessions) {
+      totals.update(
+        session.appId,
+        (value) => value + session.durationMs,
+        ifAbsent: () => session.durationMs,
+      );
+    }
+
+    final topApps = totals.entries
+        .map((entry) {
+          final app = apps.firstWhere((element) => element.id == entry.key);
+          return AppUsageSummary(app: app, durationMs: entry.value);
+        })
+        .toList()
+      ..sort((a, b) => b.durationMs.compareTo(a.durationMs));
+
+    final totalDurationMs = totals.values.fold(0, (sum, value) => sum + value);
+
+    return UsageAggregate(
+      totalDurationMs: totalDurationMs,
+      topApps: topApps,
+    );
+  }
+}

--- a/lib/domain/commentary_engine.dart
+++ b/lib/domain/commentary_engine.dart
@@ -1,0 +1,93 @@
+import '../data/models/models.dart';
+
+enum SarcasmLevel { low, medium, high }
+
+class CommentaryEngine {
+  String generate({
+    required SarcasmLevel level,
+    required UsageAggregateInput input,
+  }) {
+    final templates = _templatesForLevel(level);
+    final dominant = input.dominantCategory;
+    final topApp = input.topAppName;
+    final hoursSocial = input.socialHours.toStringAsFixed(1);
+    final hoursProductive = input.productiveHours.toStringAsFixed(1);
+
+    if (dominant == AppCategory.social) {
+      return templates.social
+          .replaceAll('{top_app}', topApp)
+          .replaceAll('{hours_social}', hoursSocial)
+          .replaceAll('{hours_productive}', hoursProductive);
+    }
+
+    if (dominant == AppCategory.video) {
+      return templates.video.replaceAll('{top_app}', topApp);
+    }
+
+    if (dominant == AppCategory.music) {
+      return templates.music.replaceAll('{top_app}', topApp);
+    }
+
+    return templates.general.replaceAll('{top_app}', topApp);
+  }
+
+  _Templates _templatesForLevel(SarcasmLevel level) {
+    switch (level) {
+      case SarcasmLevel.low:
+        return _Templates(
+          social:
+              'You spent {hours_social} hours scrolling. Balanced with {hours_productive} hours of productivity. Respect.',
+          video: 'Top app: {top_app}. Cozy cinema energy unlocked.',
+          music: 'Top app: {top_app}. Soundtrack of your year, on repeat.',
+          general: 'Top app: {top_app}. You and this app are basically roommates.',
+        );
+      case SarcasmLevel.medium:
+        return _Templates(
+          social:
+              'You spent {hours_social} hours scrolling and {hours_productive} hours being “productive.” Iconic.',
+          video: 'Top app: {top_app}. Your watchlist called. It wants a break.',
+          music: 'Top app: {top_app}. At this point they should send merch.',
+          general: 'Top app: {top_app}. Commitment issues? Not here.',
+        );
+      case SarcasmLevel.high:
+        return _Templates(
+          social:
+              'You spent {hours_social} hours scrolling and {hours_productive} hours being “productive.” Balance? Never heard of it.',
+          video:
+              'Top app: {top_app}. Your couch has your schedule memorized.',
+          music:
+              'Top app: {top_app}. If looping was a sport, you’d go pro.',
+          general:
+              'Top app: {top_app}. At this point, they should put you on payroll.',
+        );
+    }
+  }
+}
+
+class _Templates {
+  const _Templates({
+    required this.social,
+    required this.video,
+    required this.music,
+    required this.general,
+  });
+
+  final String social;
+  final String video;
+  final String music;
+  final String general;
+}
+
+class UsageAggregateInput {
+  const UsageAggregateInput({
+    required this.dominantCategory,
+    required this.topAppName,
+    required this.socialHours,
+    required this.productiveHours,
+  });
+
+  final AppCategory dominantCategory;
+  final String topAppName;
+  final double socialHours;
+  final double productiveHours;
+}

--- a/lib/features/categories/categories_screen.dart
+++ b/lib/features/categories/categories_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class CategoriesScreen extends StatelessWidget {
+  const CategoriesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Categories')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          _CategoryRow(
+            title: 'Music',
+            subtitle: 'Listening patterns and top apps',
+            icon: Icons.headphones,
+            onTap: () => context.go('/category/music'),
+          ),
+          _CategoryRow(
+            title: 'Photos',
+            subtitle: 'Camera activity and photo growth',
+            icon: Icons.camera_alt,
+            onTap: () => context.go('/category/photos'),
+          ),
+          _CategoryRow(
+            title: 'Social',
+            subtitle: 'Scroll time and content creation',
+            icon: Icons.flash_on,
+            onTap: () => context.go('/category/social'),
+          ),
+          _CategoryRow(
+            title: 'Messaging',
+            subtitle: 'Messages and calls, metadata only',
+            icon: Icons.chat_bubble,
+            onTap: () => context.go('/category/messaging'),
+          ),
+          _CategoryRow(
+            title: 'Video',
+            subtitle: 'Watch time and binge streaks',
+            icon: Icons.play_circle,
+            onTap: () => context.go('/category/video'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  const _CategoryRow({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(child: Icon(icon)),
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/features/categories/category_detail_screen.dart
+++ b/lib/features/categories/category_detail_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+class CategoryDetailScreen extends StatelessWidget {
+  const CategoryDetailScreen({super.key, required this.categoryId});
+
+  final String categoryId;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = categoryId[0].toUpperCase() + categoryId.substring(1);
+    return Scaffold(
+      appBar: AppBar(title: Text('$title detail')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          _TimeRangeSelector(),
+          const SizedBox(height: 16),
+          _MetricCard(
+            title: 'Top app',
+            value: 'Placeholder',
+            subtitle: 'Data not available on this device/OS.',
+          ),
+          const SizedBox(height: 16),
+          _MetricCard(
+            title: 'Daily breakdown',
+            value: 'Chart placeholder',
+            subtitle: 'Charts will render from local aggregates.',
+          ),
+          const SizedBox(height: 16),
+          _HighlightCard(
+            title: 'Highlights',
+            points: const [
+              'Most active day: Saturday',
+              'Longest binge: 2h 15m',
+              'Top 3 apps ready when data is available',
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimeRangeSelector extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      children: const [
+        ChoiceChip(label: Text('Today'), selected: true),
+        ChoiceChip(label: Text('Week'), selected: false),
+        ChoiceChip(label: Text('Month'), selected: false),
+        ChoiceChip(label: Text('Year'), selected: false),
+        ChoiceChip(label: Text('Custom'), selected: false),
+      ],
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+  });
+
+  final String title;
+  final String value;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Text(value, style: Theme.of(context).textTheme.headlineMedium),
+            const SizedBox(height: 8),
+            Text(subtitle),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HighlightCard extends StatelessWidget {
+  const _HighlightCard({required this.title, required this.points});
+
+  final String title;
+  final List<String> points;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            for (final point in points)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text('• $point'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/mock_repository.dart';
+import '../../domain/aggregator.dart';
+import '../../domain/commentary_engine.dart';
+
+final homeSummaryProvider = Provider<UsageAggregate>((ref) {
+  final repo = MockRepository();
+  final aggregator = UsageAggregator();
+  return aggregator.summarize(repo.loadApps(), repo.loadUsageSessions());
+});
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summary = ref.watch(homeSummaryProvider);
+    final topApp = summary.topApps.isNotEmpty
+        ? summary.topApps.first.app.displayName
+        : 'Your phone';
+    final commentary = CommentaryEngine().generate(
+      level: SarcasmLevel.medium,
+      input: UsageAggregateInput(
+        dominantCategory: summary.topApps.isNotEmpty
+            ? summary.topApps.first.app.category
+            : AppCategory.other,
+        topAppName: topApp,
+        socialHours: 4.5,
+        productiveHours: 1.2,
+      ),
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wrapper 0'),
+        actions: [
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async {},
+        child: ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            _TimeRangeChips(),
+            const SizedBox(height: 20),
+            _SummaryCard(
+              title: 'Total screen time',
+              value: _formatHours(summary.totalDurationMs),
+              subtitle: 'Across ${summary.topApps.length} apps',
+            ),
+            const SizedBox(height: 16),
+            _TopAppsCard(summary: summary),
+            const SizedBox(height: 16),
+            _CommentaryCard(text: commentary),
+            const SizedBox(height: 16),
+            _CategoryGrid(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatHours(int ms) {
+    final hours = ms / 1000 / 60 / 60;
+    return '${hours.toStringAsFixed(1)}h';
+  }
+}
+
+class _TimeRangeChips extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      children: const [
+        ChoiceChip(label: Text('Today'), selected: true),
+        ChoiceChip(label: Text('Week'), selected: false),
+        ChoiceChip(label: Text('Month'), selected: false),
+      ],
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+  });
+
+  final String title;
+  final String value;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Text(value, style: Theme.of(context).textTheme.displaySmall),
+            const SizedBox(height: 8),
+            Text(subtitle),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TopAppsCard extends StatelessWidget {
+  const _TopAppsCard({required this.summary});
+
+  final UsageAggregate summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Top apps', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            for (final app in summary.topApps.take(3))
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const CircleAvatar(child: Icon(Icons.apps)),
+                title: Text(app.app.displayName),
+                subtitle: Text(_formatHours(app.durationMs)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatHours(int ms) {
+    final hours = ms / 1000 / 60 / 60;
+    return '${hours.toStringAsFixed(1)}h';
+  }
+}
+
+class _CommentaryCard extends StatelessWidget {
+  const _CommentaryCard({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            const Icon(Icons.auto_awesome, size: 28),
+            const SizedBox(width: 12),
+            Expanded(child: Text(text)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryGrid extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Dive deeper', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        GridView.count(
+          crossAxisCount: 2,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+          children: const [
+            _CategoryTile(label: 'Music', icon: Icons.headphones),
+            _CategoryTile(label: 'Photos', icon: Icons.camera_alt),
+            _CategoryTile(label: 'Social', icon: Icons.flash_on),
+            _CategoryTile(label: 'Messaging', icon: Icons.chat_bubble),
+            _CategoryTile(label: 'Video', icon: Icons.play_circle),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryTile extends StatelessWidget {
+  const _CategoryTile({required this.label, required this.icon});
+
+  final String label;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 32),
+            const SizedBox(height: 8),
+            Text(label),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final PageController _controller = PageController();
+  int _index = 0;
+  bool _music = true;
+  bool _photos = true;
+  bool _social = true;
+  bool _messaging = true;
+  bool _video = true;
+  double _sarcasm = 1;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _controller,
+                onPageChanged: (value) => setState(() => _index = value),
+                children: [
+                  _OnboardingPage(
+                    title: 'Your Phone, Wrapped',
+                    description:
+                        'See your year like Spotify Wrapped, but for everything.',
+                  ),
+                  _OnboardingPage(
+                    title: 'Private by Default',
+                    description:
+                        'All analytics stay on your device. No accounts, no cloud, no tracking.',
+                  ),
+                  _OnboardingPage(
+                    title: 'Choose what to track',
+                    description:
+                        'Toggle the categories you want. You can change this later.',
+                    child: Wrap(
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: [
+                        _ToggleChip(
+                          label: 'Music',
+                          value: _music,
+                          onChanged: (value) =>
+                              setState(() => _music = value),
+                        ),
+                        _ToggleChip(
+                          label: 'Photos',
+                          value: _photos,
+                          onChanged: (value) =>
+                              setState(() => _photos = value),
+                        ),
+                        _ToggleChip(
+                          label: 'Social',
+                          value: _social,
+                          onChanged: (value) =>
+                              setState(() => _social = value),
+                        ),
+                        _ToggleChip(
+                          label: 'Messaging',
+                          value: _messaging,
+                          onChanged: (value) =>
+                              setState(() => _messaging = value),
+                        ),
+                        _ToggleChip(
+                          label: 'Video',
+                          value: _video,
+                          onChanged: (value) =>
+                              setState(() => _video = value),
+                        ),
+                      ],
+                    ),
+                  ),
+                  _OnboardingPage(
+                    title: 'Sarcasm intensity',
+                    description:
+                        'Pick your flavor. We keep it playful, never mean.',
+                    child: Column(
+                      children: [
+                        Slider(
+                          value: _sarcasm,
+                          min: 0,
+                          max: 2,
+                          divisions: 2,
+                          label: _sarcasmLabel(_sarcasm),
+                          onChanged: (value) =>
+                              setState(() => _sarcasm = value),
+                        ),
+                        Text(
+                          _sarcasmLabel(_sarcasm),
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Row(
+                children: [
+                  Text('${_index + 1}/4'),
+                  const Spacer(),
+                  FilledButton(
+                    onPressed: () {
+                      if (_index < 3) {
+                        _controller.nextPage(
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeOut,
+                        );
+                      } else {
+                        context.go('/');
+                      }
+                    },
+                    child: Text(_index < 3 ? 'Next' : 'Start'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _sarcasmLabel(double value) {
+    if (value < 0.5) return 'Low';
+    if (value < 1.5) return 'Medium';
+    return 'Unhinged';
+  }
+}
+
+class _OnboardingPage extends StatelessWidget {
+  const _OnboardingPage({
+    required this.title,
+    required this.description,
+    this.child,
+  });
+
+  final String title;
+  final String description;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Spacer(),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.displaySmall,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            description,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          if (child != null) ...[
+            const SizedBox(height: 24),
+            child!,
+          ],
+          const Spacer(),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToggleChip extends StatelessWidget {
+  const _ToggleChip({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterChip(
+      selected: value,
+      label: Text(label),
+      onSelected: onChanged,
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/theme.dart';
+
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeModeProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          const _SectionHeader(title: 'Theme'),
+          SegmentedButton<ThemeMode>(
+            segments: const [
+              ButtonSegment(value: ThemeMode.dark, label: Text('Dark')),
+              ButtonSegment(value: ThemeMode.light, label: Text('Light')),
+              ButtonSegment(value: ThemeMode.system, label: Text('Auto')),
+            ],
+            selected: {themeMode},
+            onSelectionChanged: (value) {
+              ref.read(themeModeProvider.notifier).state = value.first;
+            },
+          ),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Categories'),
+          _SwitchRow(title: 'Music'),
+          _SwitchRow(title: 'Photos'),
+          _SwitchRow(title: 'Social'),
+          _SwitchRow(title: 'Messaging'),
+          _SwitchRow(title: 'Video'),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Sarcasm'),
+          SwitchListTile(
+            value: true,
+            onChanged: (_) {},
+            title: const Text('Enable sarcasm'),
+            subtitle: const Text('Keep it playful, never mean.'),
+          ),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Privacy'),
+          ListTile(
+            title: const Text('Delete all data'),
+            subtitle: const Text('Wipes local analytics and Wrapped history.'),
+            trailing: const Icon(Icons.delete_outline),
+            onTap: () {},
+          ),
+          ListTile(
+            title: const Text('Export my raw stats'),
+            subtitle: const Text('Export JSON from local storage.'),
+            trailing: const Icon(Icons.download),
+            onTap: () {},
+          ),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'About'),
+          ListTile(
+            title: const Text('Wrapper 0'),
+            subtitle: const Text('Open-source vibes, offline by design.'),
+            trailing: const Icon(Icons.link),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+    );
+  }
+}
+
+class _SwitchRow extends StatefulWidget {
+  const _SwitchRow({required this.title});
+
+  final String title;
+
+  @override
+  State<_SwitchRow> createState() => _SwitchRowState();
+}
+
+class _SwitchRowState extends State<_SwitchRow> {
+  bool _value = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      value: _value,
+      onChanged: (value) => setState(() => _value = value),
+      title: Text(widget.title),
+      subtitle: const Text('Tracking enabled'),
+    );
+  }
+}

--- a/lib/features/wrapped/wrapped_screen.dart
+++ b/lib/features/wrapped/wrapped_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+class WrappedScreen extends StatelessWidget {
+  const WrappedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Wrapped')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          _WrappedHeroCard(),
+          const SizedBox(height: 16),
+          const _WrappedCard(
+            title: 'Your Year in One Screen',
+            subtitle: '1,245 hours across 112 apps',
+          ),
+          const SizedBox(height: 16),
+          const _WrappedCard(
+            title: 'Top 5 Apps',
+            subtitle: 'Spotify • Instagram • YouTube',
+          ),
+          const SizedBox(height: 16),
+          const _WrappedCard(
+            title: 'Final Roast',
+            subtitle: 'You turned doomscrolling into a full-time job.',
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.share),
+            label: const Text('Share Wrapped'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WrappedHeroCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Generate your Wrapped',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Choose a date range and get shareable story cards.',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {},
+              child: const Text('Generate'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WrappedCard extends StatelessWidget {
+  const _WrappedCard({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: const LinearGradient(
+            colors: [Color(0xFF7C3AED), Color(0xFF22D3EE)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(24),
+        ),
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(color: Colors.white),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              subtitle,
+              style:
+                  Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: Colors.white70,
+                      ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'Wrapper 0',
+                  style: TextStyle(color: Colors.white70),
+                ),
+                const Icon(Icons.auto_awesome, color: Colors.white70),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app/app.dart';
+
+void main() {
+  runApp(const ProviderScope(child: Wrapper0App()));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,23 @@
+name: wrapper_0
+description: Offline yearly recap for your entire phone.
+publish_to: "none"
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.5.1
+  go_router: ^13.2.0
+  shared_preferences: ^2.2.2
+  intl: ^0.19.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true

--- a/test/aggregator_test.dart
+++ b/test/aggregator_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wrapper_0/data/models/models.dart';
+import 'package:wrapper_0/domain/aggregator.dart';
+
+void main() {
+  test('aggregator totals duration and ranks apps', () {
+    final apps = [
+      const AppInfo(
+        id: 'a',
+        packageName: 'a',
+        displayName: 'App A',
+        category: AppCategory.music,
+        platform: 'android',
+      ),
+      const AppInfo(
+        id: 'b',
+        packageName: 'b',
+        displayName: 'App B',
+        category: AppCategory.social,
+        platform: 'android',
+      ),
+    ];
+
+    final sessions = [
+      UsageSession(
+        id: '1',
+        appId: 'a',
+        startTimestamp: DateTime(2024, 1, 1),
+        endTimestamp: DateTime(2024, 1, 1, 1),
+        durationMs: 1000,
+        dayKey: '2024-01-01',
+        weekKey: '2024-W1',
+        monthKey: '2024-01',
+        yearKey: '2024',
+      ),
+      UsageSession(
+        id: '2',
+        appId: 'b',
+        startTimestamp: DateTime(2024, 1, 2),
+        endTimestamp: DateTime(2024, 1, 2, 1),
+        durationMs: 2000,
+        dayKey: '2024-01-02',
+        weekKey: '2024-W1',
+        monthKey: '2024-01',
+        yearKey: '2024',
+      ),
+    ];
+
+    final aggregate = UsageAggregator().summarize(apps, sessions);
+
+    expect(aggregate.totalDurationMs, 3000);
+    expect(aggregate.topApps.first.app.id, 'b');
+  });
+}

--- a/test/commentary_engine_test.dart
+++ b/test/commentary_engine_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wrapper_0/domain/commentary_engine.dart';
+import 'package:wrapper_0/data/models/app_info.dart';
+
+void main() {
+  test('commentary engine selects social template for social dominance', () {
+    final engine = CommentaryEngine();
+    final output = engine.generate(
+      level: SarcasmLevel.medium,
+      input: const UsageAggregateInput(
+        dominantCategory: AppCategory.social,
+        topAppName: 'Instagram',
+        socialHours: 10,
+        productiveHours: 2,
+      ),
+    );
+
+    expect(output, contains('scrolling'));
+    expect(output, contains('Instagram'));
+  });
+
+  test('commentary engine adapts intensity', () {
+    final engine = CommentaryEngine();
+    final low = engine.generate(
+      level: SarcasmLevel.low,
+      input: const UsageAggregateInput(
+        dominantCategory: AppCategory.music,
+        topAppName: 'Spotify',
+        socialHours: 2,
+        productiveHours: 5,
+      ),
+    );
+    final high = engine.generate(
+      level: SarcasmLevel.high,
+      input: const UsageAggregateInput(
+        dominantCategory: AppCategory.music,
+        topAppName: 'Spotify',
+        socialHours: 2,
+        productiveHours: 5,
+      ),
+    );
+
+    expect(low, isNot(equals(high)));
+  });
+}


### PR DESCRIPTION
### Motivation

- Scaffold a production-oriented, offline-first Flutter app for the "Wrapper 0" yearly-phone-recap concept with a clear modular architecture.
- Provide a privacy-first onboarding and settings surface so tracking is opt-in and reversible.
- Ship local analytics primitives and a rule-based sarcastic commentary engine so the core UX can be iterated without any network dependencies.

### Description

- Add project configuration and entrypoint: `pubspec.yaml`, `analysis_options.yaml`, and `lib/main.dart`, and wire up the app in `lib/app/app.dart` using `flutter_riverpod` and `go_router`.
- Implement theming and navigation: a Material 3 neon-inspired theme in `lib/app/theme.dart` and a bottom-tab `ShellScaffold` + routes in `lib/app/router.dart` (Home, Categories, Wrapped, Settings, Onboarding, Category detail).
- Add data models and a mock data source: `lib/data/models/*` (`AppInfo`, `UsageSession`, `PhotoEvent`, aggregates) and `lib/data/repositories/mock_repository.dart` to simulate app lists and sessions.
- Implement aggregation and commentary domain logic: `lib/domain/aggregator.dart` with `UsageAggregator` and `lib/domain/commentary_engine.dart` with a rule/template-based `CommentaryEngine` and `SarcasmLevel` support.
- Build UI screens: onboarding flow in `lib/features/onboarding/onboarding_screen.dart`, home dashboard in `lib/features/home/home_screen.dart`, categories and detail screens in `lib/features/categories/*`, wrapped generator UI in `lib/features/wrapped/wrapped_screen.dart` (uses `RepaintBoundary`-style card rendering), and settings in `lib/features/settings/settings_screen.dart`.
- Add lightweight unit tests: `test/aggregator_test.dart` and `test/commentary_engine_test.dart` that validate aggregation totals/ranking and commentary template selection.

### Testing

- Added unit tests `test/aggregator_test.dart` and `test/commentary_engine_test.dart` that exercise `UsageAggregator` and `CommentaryEngine` respectively, and they assert expected outputs and template selection.
- No automated tests were executed as part of this PR; the test files are included and ready to run with `flutter test` in CI or locally.
- Static linting rules were added via `analysis_options.yaml` to enforce consistent style during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820baf2acc8330976cc6d70d141ef1)